### PR TITLE
docs(readme): add CLI usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use the Aptos CLI, in your project environment, run the `npx aptos` command, 
 npx aptos
 ```
 
-After the binary is installed, extra arguments are forwarded to the Aptos CLI. For example:
+Wrapper-specific flags such as `--install`, `--update`, `--binary-path`, and `--direct-download` are handled by the Node CLI wrapper. Other arguments are forwarded to the Aptos CLI binary, and this forwarding also works when the binary needs to be installed as part of the same invocation. For example:
 
 ```bash
 npx aptos --help

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ To use the Aptos CLI, in your project environment, run the `npx aptos` command, 
 npx aptos
 ```
 
+After the binary is installed, extra arguments are forwarded to the Aptos CLI. For example:
+
+```bash
+npx aptos --help
+```
+
+```bash
+npx aptos move compile --package-dir ./my-move-package
+```
+
 ### Using a Custom Binary
 
 If you already have the Aptos CLI binary installed on your system, you can specify its path to use it directly:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The README already described running `npx aptos` to list commands, but it did not show that additional arguments are forwarded to the installed Aptos CLI after installation.

This change adds short examples (`--help` and `move compile`) so readers can see the typical invocation pattern without guessing.
<!-- CURSOR_AGENT_PR_BODY_END -->

Closes https://github.com/aptos-labs/aptos-cli/issues/24

<div><a href="https://cursor.com/agents/bc-c602381e-1b51-42a1-8122-eafc96eaa987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c602381e-1b51-42a1-8122-eafc96eaa987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

